### PR TITLE
Add TERMINATED status for batch processing workers

### DIFF
--- a/lib/batchProcessing/batchProcessingService.ts
+++ b/lib/batchProcessing/batchProcessingService.ts
@@ -30,6 +30,7 @@ export enum BatchPartitionStatus {
   FAILED = "failed",
   CANCELLED = "cancelled",
   PAUSED = "paused",
+  TERMINATED = "terminated",
 }
 
 /**
@@ -207,7 +208,7 @@ class Worker extends EventEmitter {
       clearInterval(this.processingInterval);
       this.processingInterval = null;
     }
-    this._status = "terminated";
+    this._status = BatchPartitionStatus.TERMINATED;
   }
 }
 


### PR DESCRIPTION
## Summary
- extend `BatchPartitionStatus` enum with `TERMINATED`
- set worker status to the new enum on termination

## Testing
- `npm test` *(fails: `jest: not found`)*