### PR TITLE
Add papaparse dependency for client parsing

### DIFF
--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from "react";
+import { parseFileClient } from "../utils/clientParse";
 
 // Maximum file size: 500MB in bytes
 const MAX_FILE_SIZE = 500 * 1024 * 1024;
@@ -13,6 +14,7 @@ const CHUNK_SIZE = 5 * 1024 * 1024;
 
 interface FileUploadProps {
   onFilesSelected: (files: File[], projectId?: string) => void;
+  onPreviewParsed?: (preview: Record<string, unknown>[]) => void;
   accept?: string;
   multiple?: boolean;
   maxSize?: number;
@@ -76,12 +78,21 @@ const FileUpload: React.FC<FileUploadProps> = ({
     return { valid: validFiles, errors: fileErrors };
   };
 
-  const handleFiles = (files: FileList | null) => {
+  const handleFiles = async (files: FileList | null) => {
     if (files && files.length > 0) {
       const { valid, errors } = validateFiles(files);
 
       if (valid.length > 0) {
         setSelectedFiles(valid);
+
+        if (onPreviewParsed) {
+          try {
+            const preview = await parseFileClient(valid[0]);
+            onPreviewParsed(preview);
+          } catch (err) {
+            console.warn('Preview parsing failed', err);
+          }
+        }
 
         if (useChunkedUpload) {
           handleChunkedUpload(valid[0]);

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "uuid": "^11.1.0",
     "winston": "^3.17.0",
     "winston-daily-rotate-file": "^5.0.0",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "papaparse": "^5.4.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/utils/clientParse.ts
+++ b/utils/clientParse.ts
@@ -1,0 +1,78 @@
+import Papa from 'papaparse';
+
+export async function parseFileClient(
+  file: File,
+  sampleSize: number = 5
+): Promise<Record<string, unknown>[]> {
+  const extension = file.name.split('.').pop()?.toLowerCase();
+
+  if (extension === 'csv') {
+    try {
+      return new Promise((resolve, reject) => {
+        Papa.parse(file, {
+          header: true,
+          preview: sampleSize,
+          skipEmptyLines: true,
+          complete: (results: { data: Record<string, unknown>[] }) => {
+            resolve(results.data);
+          },
+          error: (err: unknown) => reject(err),
+        });
+      });
+    } catch {
+      // Fallback simple CSV parser if papaparse is unavailable
+      return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+          const text = reader.result as string;
+          const [headerLine, ...rows] = text.split(/\r?\n/).filter(Boolean);
+          const headers = headerLine.split(',');
+          const data = rows.slice(0, sampleSize).map((row) => {
+            const values = row.split(',');
+            const obj: Record<string, unknown> = {};
+            headers.forEach((h, i) => {
+              obj[h] = values[i];
+            });
+            return obj;
+          });
+          resolve(data);
+        };
+        reader.onerror = () => reject(reader.error);
+        reader.readAsText(file);
+      });
+    }
+  }
+
+  if (extension === 'xlsx' || extension === 'xls') {
+    const XLSX = await import('xlsx');
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        try {
+          const data = new Uint8Array(reader.result as ArrayBuffer);
+          const workbook = XLSX.read(data, { type: 'array' });
+          const sheet = workbook.SheetNames[0];
+          const worksheet = workbook.Sheets[sheet];
+          const json = XLSX.utils.sheet_to_json<any[]>(worksheet, { header: 1 });
+          const headers = json[0] as string[];
+          const records = (json.slice(1, sampleSize + 1) as any[][]).map(
+            (row) => {
+              const obj: Record<string, unknown> = {};
+              headers.forEach((h, i) => {
+                obj[h] = row[i];
+              });
+              return obj;
+            }
+          );
+          resolve(records);
+        } catch (err) {
+          reject(err);
+        }
+      };
+      reader.onerror = () => reject(reader.error);
+      reader.readAsArrayBuffer(file);
+    });
+  }
+
+  throw new Error('Unsupported file type');
+}


### PR DESCRIPTION
## Summary
- switch to static import of papaparse in `parseFileClient`
- declare `papaparse` dependency

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: EHOSTUNREACH)*