### PR TITLE
Add unmapped filter for column mapping

### DIFF
--- a/components/schema/ColumnMappingInterface.tsx
+++ b/components/schema/ColumnMappingInterface.tsx
@@ -623,6 +623,7 @@ const ColumnMappingInterface: React.FC<ColumnMappingInterfaceProps> = ({
               <ColumnMappingDisplay
                 fileColumns={fileColumns}
                 schemaColumns={schemaColumns}
+                mappings={mappings}
                 isLoading={isLoading}
                 onSelectFileColumn={handleSelectFileColumn}
                 onSelectSchemaColumn={handleSelectSchemaColumn}


### PR DESCRIPTION
## Summary
- add `mappings` prop to `ColumnMappingDisplay`
- allow filtering file columns to show only unmapped columns
- pass current mappings from `ColumnMappingInterface`

## Testing
- `npx jest` *(fails: request to https://registry.npmjs.org/jest failed, reason: connect EHOSTUNREACH)*