### PR TITLE
Use shared replica client for API routes

### DIFF
--- a/src/pages/api/column-merges.ts
+++ b/src/pages/api/column-merges.ts
@@ -1,18 +1,9 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "../../../lib/authOptions";
-import { PrismaClient } from "@prisma/client";
 import { createMergedColumnView } from "../../../lib/columnMergeService";
+import { getPrismaClient } from "../../../lib/prisma/replicaClient";
 
-// Initialize Prisma client (singleton)
-let prismaInstance: PrismaClient | null = null;
-
-function getPrismaClient(): PrismaClient {
-  if (!prismaInstance) {
-    prismaInstance = new PrismaClient();
-  }
-  return prismaInstance;
-}
 
 export default async function handler(
   req: NextApiRequest,

--- a/src/pages/api/column-merges/[id].ts
+++ b/src/pages/api/column-merges/[id].ts
@@ -3,16 +3,8 @@ import { getServerSession } from "next-auth/next";
 import { authOptions } from "../../../../lib/authOptions";
 import { PrismaClient } from "@prisma/client";
 import { dropMergedColumnView } from "../../../../lib/columnMergeService";
+import { getPrismaClient } from "../../../../lib/prisma/replicaClient";
 
-// Initialize Prisma client (singleton)
-let prismaInstance: PrismaClient | null = null;
-
-function getPrismaClient(): PrismaClient {
-  if (!prismaInstance) {
-    prismaInstance = new PrismaClient();
-  }
-  return prismaInstance;
-}
 
 export default async function handler(
   req: NextApiRequest,

--- a/src/pages/api/debug/check-files-db.ts
+++ b/src/pages/api/debug/check-files-db.ts
@@ -1,17 +1,8 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "../../../../lib/authOptions";
-import { PrismaClient } from "@prisma/client";
+import { getPrismaClient } from "../../../../lib/prisma/replicaClient";
 
-// Initialize Prisma client (singleton)
-let prismaInstance: PrismaClient | null = null;
-
-function getPrismaClient(): PrismaClient {
-  if (!prismaInstance) {
-    prismaInstance = new PrismaClient();
-  }
-  return prismaInstance;
-}
 
 export default async function handler(
   req: NextApiRequest,

--- a/src/pages/api/debug/files-without-project.ts
+++ b/src/pages/api/debug/files-without-project.ts
@@ -1,17 +1,8 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "../../../../lib/authOptions";
-import { PrismaClient } from "@prisma/client";
+import { getPrismaClient } from "../../../../lib/prisma/replicaClient";
 
-// Initialize Prisma client (singleton)
-let prismaInstance: PrismaClient | null = null;
-
-function getPrismaClient(): PrismaClient {
-  if (!prismaInstance) {
-    prismaInstance = new PrismaClient();
-  }
-  return prismaInstance;
-}
 
 export default async function handler(
   req: NextApiRequest,

--- a/src/pages/api/debug/fix-file-projects.ts
+++ b/src/pages/api/debug/fix-file-projects.ts
@@ -1,17 +1,8 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "../../../../lib/authOptions";
-import { PrismaClient } from "@prisma/client";
+import { getPrismaClient } from "../../../../lib/prisma/replicaClient";
 
-// Initialize Prisma client (singleton)
-let prismaInstance: PrismaClient | null = null;
-
-function getPrismaClient(): PrismaClient {
-  if (!prismaInstance) {
-    prismaInstance = new PrismaClient();
-  }
-  return prismaInstance;
-}
 
 export default async function handler(
   req: NextApiRequest,

--- a/src/pages/api/file-data/[id].ts
+++ b/src/pages/api/file-data/[id].ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth/next";
-import { PrismaClient } from "@prisma/client";
+import { getPrismaClient } from "../../../../lib/prisma/replicaClient";
 import { executeQuery } from "../../../../lib/database";
 import {
   handleFileError,
@@ -9,15 +9,6 @@ import {
 } from "../../../../lib/errorHandling";
 import { authOptions } from "../../../../lib/authOptions";
 
-// Initialize Prisma client (singleton)
-let prismaInstance: PrismaClient | null = null;
-
-function getPrismaClient(): PrismaClient {
-  if (!prismaInstance) {
-    prismaInstance = new PrismaClient();
-  }
-  return prismaInstance;
-}
 
 export default async function handler(
   req: NextApiRequest,

--- a/src/pages/api/file-synopsis/[id].ts
+++ b/src/pages/api/file-synopsis/[id].ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth/next";
-import { PrismaClient } from "@prisma/client";
+import { getPrismaClient } from "../../../../lib/prisma/replicaClient";
 import { executeQuery } from "../../../../lib/database";
 import {
   handleFileError,
@@ -9,15 +9,6 @@ import {
 } from "../../../../lib/errorHandling";
 import { authOptions } from "../../../../lib/authOptions";
 
-// Initialize Prisma client (singleton)
-let prismaInstance: PrismaClient | null = null;
-
-function getPrismaClient(): PrismaClient {
-  if (!prismaInstance) {
-    prismaInstance = new PrismaClient();
-  }
-  return prismaInstance;
-}
 
 // Cache for file synopsis data (fileId -> synopsis data)
 const synopsisCache = new Map<

--- a/src/pages/api/files/[id]/errors.ts
+++ b/src/pages/api/files/[id]/errors.ts
@@ -1,17 +1,8 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth/next";
-import { PrismaClient } from "@prisma/client";
 import { authOptions } from "../../../../../lib/authOptions";
+import { getPrismaClient } from "../../../../../lib/prisma/replicaClient";
 
-// Initialize Prisma client (singleton)
-let prismaInstance: PrismaClient | null = null;
-
-function getPrismaClient(): PrismaClient {
-  if (!prismaInstance) {
-    prismaInstance = new PrismaClient();
-  }
-  return prismaInstance;
-}
 
 export default async function handler(
   req: NextApiRequest,


### PR DESCRIPTION
## Summary
- use `getPrismaClient` from `lib/prisma/replicaClient` in API routes
- remove ad-hoc PrismaClient instances

## Testing
- `npx jest` *(fails: connect EHOSTUNREACH)*
- `npx tsc --noEmit` *(fails: various existing type errors)*