### PR TITLE
Add CSV upload Cypress flow

### DIFF
--- a/cypress/e2e/csv-upload-flow.cy.js
+++ b/cypress/e2e/csv-upload-flow.cy.js
@@ -1,0 +1,31 @@
+// Cypress flow tests for uploading CSV files
+
+describe("CSV Upload Flow", () => {
+  beforeEach(() => {
+    cy.login();
+    cy.visit("/upload");
+  });
+
+  it("should upload a CSV file via drag and drop", () => {
+    cy.get('input[type="file"]').attachFile("first_upload.csv", {
+      subjectType: "drag-n-drop",
+    });
+
+    cy.contains("File uploaded successfully").should("be.visible");
+
+    cy.visit("/files");
+    cy.contains("first_upload.csv").should("be.visible");
+  });
+
+  it("should upload multiple CSV files sequentially", () => {
+    cy.uploadFile("first_upload.csv", "text/csv");
+    cy.contains("File uploaded successfully").should("be.visible");
+
+    cy.uploadFile("second_upload.csv", "text/csv");
+    cy.contains("File uploaded successfully").should("be.visible");
+
+    cy.visit("/files");
+    cy.contains("first_upload.csv").should("be.visible");
+    cy.contains("second_upload.csv").should("be.visible");
+  });
+});


### PR DESCRIPTION
## Summary
- add Cypress e2e covering CSV upload via drag/drop and sequential uploads

## Testing
- `npx jest` *(fails: request to registry.npmjs.org failed)*
- `npm run lint` *(fails: `next` not found)*